### PR TITLE
Create Task goes to Task Summary instead of Find Task

### DIFF
--- a/screen/SimpleScreens/Task/FindTask.xml
+++ b/screen/SimpleScreens/Task/FindTask.xml
@@ -22,7 +22,7 @@ along with this software (see the LICENSE.md file). If not, see
     <transition name="milestoneSummary"><default-response url="../../Project/MilestoneSummary"/></transition>
 
     <transition name="createTask"><service-call name="mantle.work.TaskServices.create#Task" in-map="context"/>
-        <default-response url="."/></transition>
+        <default-response url="../TaskSummary"/></transition>
 
     <!-- row selection action form transitions -->
     <transition name="updateTask"><service-call name="mantle.work.TaskServices.update#Task" in-map="context"/>


### PR DESCRIPTION
User experience improvement. Now when creating a new task the user is directed to the Task Summary screen.

Previously the user was directed back to the Find Task screen, which is great for bulk editing, but not ideal for creating and enhancing individual Tasks. Creating individual Tasks is the most common scenario. The user can click the back button to return to Find Task, but they couldn't click a forward (or any other) button to go to Task Summary. Bulk Task entry should be handled through an import.